### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/notivue/nuxt/module.mjs
+++ b/packages/notivue/nuxt/module.mjs
@@ -22,7 +22,7 @@ const module = defineNuxtModule({
             getContents() {
                return `
                   import { createNotivue } from 'notivue'
-                  import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+                  import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
                   function nullToInf(obj) {
                      if (obj == null) return 1 / 0


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.