### PR TITLE
fix(readme): live demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Fully-featured notification system for Vue and Nuxt
 
-[Live Demo](https://notivue.smastrom.dev) - [Documentation](https://notivuedocs.netlify.app)
+[Live Demo](https://notivue.smastrom.io) - [Documentation](https://notivuedocs.netlify.app)
 
 ---
 


### PR DESCRIPTION
The URL provided in the repository end with dot io, not dot dev. Currently, the demo is not accessible from the readme.md.