### PR TITLE
fix: remove redundant margin property

### DIFF
--- a/packages/notivue/Notifications/notifications.css
+++ b/packages/notivue/Notifications/notifications.css
@@ -138,7 +138,6 @@
 
 .Notivue__close {
    position: relative;
-   margin: 0;
    cursor: pointer;
    padding: calc(var(--nv-spacing) / 2);
    margin: var(--nv-spacing) var(--nv-spacing) var(--nv-spacing) 0;


### PR DESCRIPTION
![icons margin](https://github.com/smastrom/notivue/assets/16855468/ed6a9ee8-67dd-4000-b262-2fdc130ac51a)

The close icon has an extra `padding` attribute than the icon on the left, causing them to be at different distances from the border.

This PR increases `margin` of the left icon, makes the space on both sides equal in width.