### PR TITLE
Core, Tests - Replace motion config with CSS variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
    pull_request:
       branches:
          - main
+         - v3
    push:
       branches:
          - main
+         - v3
       tags-ignore:
          - '*'
    workflow_call:

--- a/packages/notivue/core/animations.css
+++ b/packages/notivue/core/animations.css
@@ -1,27 +1,15 @@
+:root {
+   --nv-enter-animation: Notivue__enter-kf 350ms cubic-bezier(0.5, 1, 0.25, 1);
+   --nv-leave-animation: Notivue__leave-kf 350ms ease;
+   --nv-clear-all-animation: Notivue__clearAll-kf 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 [data-notivue-align='top'] {
-   & .Notivue__enter,
-   & .Notivue__leave {
-      --notivue-ty: -200%;
-   }
+   --notivue-ty: -200%;
 }
 
 [data-notivue-align='bottom'] {
-   & .Notivue__enter,
-   & .Notivue__leave {
-      --notivue-ty: 200%;
-   }
-}
-
-.Notivue__enter {
-   animation: Notivue__enter-kf 350ms cubic-bezier(0.5, 1, 0.25, 1);
-}
-
-.Notivue__leave {
-   animation: Notivue__leave-kf 350ms ease;
-}
-
-.Notivue__clearAll {
-   animation: Notivue__clearAll-kf 500ms cubic-bezier(0.22, 1, 0.36, 1);
+   --notivue-ty: 200%;
 }
 
 @keyframes Notivue__enter-kf {

--- a/packages/notivue/core/constants.ts
+++ b/packages/notivue/core/constants.ts
@@ -43,6 +43,22 @@ export const DEFAULT_NOTIFICATION_OPTIONS = {
    [NotificationTypeKeys.PROMISE_REJECT]: {},
 } as NotivueConfigRequired['notifications']
 
+export const MOTION_VARS = {
+   enterAnimation: '--nv-enter-animation',
+   leaveAnimation: '--nv-leave-animation',
+   clearAllAnimation: '--nv-clear-all-animation',
+   transformTransition: '--nv-transform-transition',
+} as const
+
+export const DEFAULT_TRANSFORM_TRANSITION = 'transform 0.35s cubic-bezier(0.5, 1, 0.25, 1)'
+
+export const MOTION_VARS_CSS = {
+   enterAnimation: `var(${MOTION_VARS.enterAnimation})`,
+   leaveAnimation: `var(${MOTION_VARS.leaveAnimation})`,
+   clearAllAnimation: `var(${MOTION_VARS.clearAllAnimation})`,
+   transformTransition: `var(${MOTION_VARS.transformTransition}, ${DEFAULT_TRANSFORM_TRANSITION})`,
+} as const
+
 export const DEFAULT_CONFIG: NotivueConfigRequired = {
    pauseOnHover: true,
    pauseOnTouch: true,
@@ -53,10 +69,4 @@ export const DEFAULT_CONFIG: NotivueConfigRequired = {
    notifications: DEFAULT_NOTIFICATION_OPTIONS,
    limit: -1,
    avoidDuplicates: false,
-   transition: 'transform 0.35s cubic-bezier(0.5, 1, 0.25, 1)',
-   animations: {
-      enter: CLASS_PREFIX + 'enter',
-      leave: CLASS_PREFIX + 'leave',
-      clearAll: CLASS_PREFIX + 'clearAll',
-   },
 }

--- a/packages/notivue/core/createStore.ts
+++ b/packages/notivue/core/createStore.ts
@@ -14,9 +14,9 @@ import type {
    NotivueStore,
 } from 'notivue'
 
-import { ref, shallowRef, triggerRef, unref, isRef, type Ref } from 'vue'
+import { ref, shallowRef, triggerRef, unref, isRef, type CSSProperties, type Ref } from 'vue'
 
-import { DEFAULT_CONFIG, NotificationTypeKeys as NType } from './constants'
+import { DEFAULT_CONFIG, MOTION_VARS_CSS, NotificationTypeKeys as NType } from './constants'
 
 import {
    createConfigRefs,
@@ -60,7 +60,7 @@ export function createConfig(userConfig: NotivueConfig, isRunning: Readonly<Ref<
             const prev = config[key as K].value as Obj
             const next = newConfig[key as K] as any
 
-            config[key as K].value = mergeDeep(prev, next)
+            config[key as K].value = mergeDeep(prev, next) as any
          } else {
             config[key as K].value = newConfig[key as K] as any
          }
@@ -169,12 +169,15 @@ export function createItems(config: ConfigSlice, queue: QueueSlice) {
 }
 
 export function createElements() {
-   type AnimationAttrs = { class: string; onAnimationend: () => void }
+   type MotionAttrs = {
+      style?: CSSProperties
+      onAnimationend?: (e?: AnimationEvent) => void
+   }
 
    return {
       root: ref<HTMLElement | null>(null),
-      rootAttrs: shallowRef<Partial<AnimationAttrs>>({}),
-      setRootAttrs(newAttrs: Partial<AnimationAttrs>) {
+      rootAttrs: shallowRef<Partial<MotionAttrs>>({}),
+      setRootAttrs(newAttrs: Partial<MotionAttrs>) {
          this.rootAttrs.value = newAttrs
       },
       items: ref<HTMLElement[]>([]),
@@ -186,10 +189,10 @@ export function createElements() {
    } as {
       // Suppress TS7056
       root: Ref<HTMLElement | null>
-      rootAttrs: Ref<Partial<AnimationAttrs>>
+      rootAttrs: Ref<Partial<MotionAttrs>>
       items: Ref<HTMLElement[]>
       containers: Ref<HTMLElement[]>
-      setRootAttrs(newAttrs: Partial<AnimationAttrs>): void
+      setRootAttrs(newAttrs: Partial<MotionAttrs>): void
       getSortedItems(): HTMLElement[]
    }
 }
@@ -206,7 +209,6 @@ export function createAnimations(
          this.isReducedMotion.value = newVal
       },
       playLeave(id: string, { isDestroy = false, isUserTriggered = false } = {}) {
-         const { leave = '' } = config.animations.value
          const item = items.get(id)
 
          window.clearTimeout(item?.timeout as number)
@@ -229,7 +231,7 @@ export function createAnimations(
             items.remove(id)
          }
 
-         if (!item || !leave || isDestroy || this.isReducedMotion.value) {
+         if (!item || isDestroy || this.isReducedMotion.value) {
             items.addLifecycleEvent()
 
             return onAnimationend()
@@ -241,7 +243,7 @@ export function createAnimations(
                zIndex: -1,
             },
             animationAttrs: {
-               class: leave,
+               style: { animation: MOTION_VARS_CSS.leaveAnimation },
                onAnimationend,
             },
          })
@@ -251,17 +253,15 @@ export function createAnimations(
       playClearAll() {
          items.entries.value.forEach((e) => window.clearTimeout(e.timeout as number))
 
-         const { clearAll = '' } = config.animations.value
-
          const onAnimationend = () => {
             queue.clear()
             items.clear()
          }
 
-         if (!clearAll || this.isReducedMotion.value) return onAnimationend()
+         if (this.isReducedMotion.value) return onAnimationend()
 
          elements.setRootAttrs({
-            class: clearAll,
+            style: { animation: MOTION_VARS_CSS.clearAllAnimation },
             onAnimationend,
          })
       },
@@ -270,7 +270,6 @@ export function createAnimations(
 
          const isReduced = this.isReducedMotion.value || isImmediate
          const isTopAlign = config.position.value.startsWith('top')
-         const leaveClass = config.animations.value.leave
 
          let accPrevHeights = 0
 
@@ -279,12 +278,12 @@ export function createAnimations(
             const item = items.get(id)
 
             if (!el || !item) continue
-            if (item.animationAttrs.class === leaveClass) continue
+            if (item.animationAttrs.style?.animation === MOTION_VARS_CSS.leaveAnimation) continue
 
             items.update(id, {
                positionStyles: {
                   transform: `translate3d(0, ${accPrevHeights}px, 0)`,
-                  transition: isReduced ? 'none' : config.transition.value,
+                  transition: isReduced ? 'none' : MOTION_VARS_CSS.transformTransition,
                },
             })
 
@@ -479,11 +478,13 @@ export function createNotifyProxies({
                createdAt,
                duplicateCount: 0,
                animationAttrs: {
-                  class: animations.isReducedMotion.value ? '' : config.animations.value.enter,
+                  style: animations.isReducedMotion.value
+                     ? {}
+                     : { animation: MOTION_VARS_CSS.enterAnimation },
                   onAnimationend() {
-                     if (item.animationAttrs.class === config.animations.value.enter) {
+                     if (item.animationAttrs.style?.animation === MOTION_VARS_CSS.enterAnimation) {
                         items.update(entry.id, {
-                           animationAttrs: { class: '', onAnimationend: () => {} },
+                           animationAttrs: { style: {}, onAnimationend: () => {} },
                         })
                      }
                   },

--- a/packages/notivue/core/types.ts
+++ b/packages/notivue/core/types.ts
@@ -48,12 +48,6 @@ export type Position =
    | 'bottom-center'
    | 'bottom-right'
 
-export interface NotivueAnimations {
-   enter?: string
-   leave?: string
-   clearAll?: string
-}
-
 export interface NotificationOptions {
    /** Default title (`''` hides the title). */
    title?: string | Ref<string>
@@ -75,9 +69,6 @@ export interface NotivueConfig {
    /** Stream anchor; see `Position`. */
    position?: Position
    notifications?: Partial<NotificationTypesOptions>
-   animations?: NotivueAnimations
-   /** Must match `transform <duration> <timing-function>`. */
-   transition?: string
    teleportTo?: string | HTMLElement | false
    /** Use `-1` for unlimited. @default -1 */
    limit?: number
@@ -112,7 +103,7 @@ export interface HiddenInternalItemData {
    timeout: number | undefined | (() => void) | void
    resumedAt: number
    remaining: number
-   animationAttrs: Partial<{ class: string; onAnimationend: () => void }>
+   animationAttrs: Partial<{ style: CSSProperties; onAnimationend: (e?: AnimationEvent) => void }>
    positionStyles: CSSProperties
 }
 

--- a/tests/Notivue/components/Notivue.vue
+++ b/tests/Notivue/components/Notivue.vue
@@ -25,8 +25,7 @@ const config = useNotivue()
 const { startInstance, stopInstance } = useNotivueInstance()
 const { entries, queue } = useNotifications()
 
-const { pauseOnTouch, pauseOnHover, teleportTo, limit, animations, enqueue, avoidDuplicates } =
-   toRefs(cyProps)
+const { pauseOnTouch, pauseOnHover, teleportTo, limit, enqueue, avoidDuplicates } = toRefs(cyProps)
 
 const autoClearCount = ref(0)
 const manualClearCount = ref(0)
@@ -36,10 +35,8 @@ const manualClearCount = ref(0)
  * ==================================================================================== */
 
 watchEffect(() => {
-   if (animations?.value) config.animations.value = animations.value
    if (pauseOnTouch?.value) config.pauseOnTouch.value = pauseOnTouch.value
    if (pauseOnHover?.value) config.pauseOnHover.value = pauseOnHover.value
-   if (animations?.value) config.animations.value = animations.value
    if (teleportTo?.value) config.teleportTo.value = teleportTo.value
    if (limit?.value) config.limit.value = limit.value
    if (enqueue?.value) config.enqueue.value = enqueue.value

--- a/tests/Notivue/config-animations.cy.ts
+++ b/tests/Notivue/config-animations.cy.ts
@@ -1,41 +1,20 @@
-import type { VueWrapper } from '@vue/test-utils'
-
-// In cypress/support/styles.css
-const customAnims = {
-   enter: 'fade-in',
-   leave: 'fade-out',
-   clearAll: 'fade-all',
-}
-
 describe('Animations', () => {
-   it('Custom animations classes are toggled properly', () => {
-      cy.mountNotivue({ config: { animations: customAnims } }).checkAnimations(
-         `.${customAnims.enter}`,
-         `.${customAnims.leave}`,
-         `.${customAnims.clearAll}`
-      )
+   it('Enter, leave, and clearAll use motion CSS variables', () => {
+      cy.mountNotivue().checkAnimations()
    })
 
-   it('Custom animations are merged properly with defaults', () => {
-      cy.mountNotivue({
-         config: {
-            animations: {
-               leave: customAnims.leave,
-               clearAll: customAnims.clearAll,
-            },
-         },
-      }).checkAnimations('.Notivue__enter', '.fade-out', '.fade-all')
-   })
-
-   it('Should update animations config dynamically', () => {
+   it('Custom motion CSS variables are applied', () => {
       cy.mountNotivue()
-         .get<VueWrapper>('@vue')
-         .then((wrapper) => wrapper.setProps({ animations: customAnims }))
 
-         .checkAnimations(
-            `.${customAnims.enter}`,
-            `.${customAnims.leave}`,
-            `.${customAnims.clearAll}`
+      cy.document().then((doc) => {
+         doc.documentElement.style.setProperty('--nv-enter-animation', 'fade-kf 300ms ease')
+         doc.documentElement.style.setProperty('--nv-leave-animation', 'fade-kf 300ms ease')
+         doc.documentElement.style.setProperty(
+            '--nv-clear-all-animation',
+            'fade-kf 600ms ease forwards'
          )
+      })
+
+      cy.checkAnimations()
    })
 })

--- a/tests/Notivue/prefers-reduced-motion.cy.ts
+++ b/tests/Notivue/prefers-reduced-motion.cy.ts
@@ -5,17 +5,19 @@ describe('prefers-reduced-motion', () => {
       })
    })
 
-   it('Should not add enter/leave animation classes', () => {
+   it('Should not add enter/leave animation styles', () => {
       cy.mountNotivue()
          .get('.PushAndRenderClear')
          .click()
-         .get('.Notivue__enter')
-         .should('not.exist')
+         .getContainer()
+         .invoke('attr', 'style')
+         .should('not.include', '--nv-enter-animation')
 
          .get('.RenderedClear')
          .click()
-         .get('.Notivue__leave')
-         .should('not.exist')
+         .getContainer()
+         .invoke('attr', 'style')
+         .should('not.include', '--nv-leave-animation')
    })
 
    it('Should not add clearAll animation', () => {
@@ -23,15 +25,17 @@ describe('prefers-reduced-motion', () => {
          .clickRandomStatic()
          .get('.ClearAll')
          .click()
-         .get('.Notivue__clearAll')
-         .should('not.exist')
+         .get('ol')
+         .invoke('attr', 'style')
+         .should('not.include', '--nv-clear-all-animation')
    })
 
    it('No transition should be applied', () => {
       cy.mountNotivue()
          .clickRandomStatic()
          .click()
-         .getNotifications()
-         .should('have.css', 'transition', 'all')
+         .get('li')
+         .invoke('attr', 'style')
+         .should('include', 'transition: none')
    })
 })

--- a/tests/config/update-config.test.ts
+++ b/tests/config/update-config.test.ts
@@ -38,19 +38,6 @@ describe('Update method', () => {
    })
 
    describe('Should merge object properties', () => {
-      test('Animations', () => {
-         const animations = { enter: 'Vitest_Enter', leave: 'Vitest_Leave' }
-
-         const config = createConfig({}, isRunning) as ConfigSlice
-
-         config.update({ animations })
-
-         expect(config.animations.value).toStrictEqual({
-            ...animations,
-            clearAll: defaultConf.animations.clearAll,
-         })
-      })
-
       test('Notification options', () => {
          const newConf: NotivueConfig['notifications'] = {
             global: { duration: Math.random() * 100 },
@@ -88,7 +75,6 @@ describe('Update method', () => {
          pauseOnHover: false,
          teleportTo: 'foo',
          limit: 20000,
-         animations: { enter: 'foo', leave: 'bar', clearAll: 'baz' },
          notifications: {
             global: { duration: 3000 },
             error: { duration: 4000 },
@@ -123,10 +109,6 @@ describe('Update method', () => {
             enqueue: !curr.enqueue,
             position: (curr.position + 'foo') as unknown as NotivueConfig['position'],
             teleportTo: curr.teleportTo + 'bar',
-            animations: {
-               enter: curr.animations.enter + 'baz',
-               leave: curr.animations.leave + 'haz',
-            },
             limit: curr.limit * 2,
             notifications: {
                global: { duration: currNot.global.duration * 2 },
@@ -151,11 +133,6 @@ describe('Update method', () => {
       expect(c.position.value).toBe(prevConf.position + 'foo')
       expect(c.teleportTo.value).toBe(prevConf.teleportTo + 'bar')
       expect(c.limit.value).toBe(prevConf.limit * 2)
-      expect(c.animations.value).toStrictEqual({
-         enter: prevConf.animations.enter + 'baz',
-         leave: prevConf.animations.leave + 'haz',
-         clearAll: prevConf.animations.clearAll,
-      })
       expect(c.notifications.value).toStrictEqual({
          global: { ...prevNot.global, duration: prevNot.global.duration * 2 },
          info: { ...prevNot.info, duration: prevNot.info.duration * 2 },

--- a/tests/cypress/support/commands-notivue.ts
+++ b/tests/cypress/support/commands-notivue.ts
@@ -3,7 +3,7 @@ import Notivue, { type CyNotivueProps } from '@/tests/Notivue/components/Notivue
 import { mount } from 'cypress/vue'
 import { createNotivue, type NotivueConfig } from 'notivue'
 
-import { DEFAULT_DURATION } from '@/core/constants'
+import { DEFAULT_DURATION, MOTION_VARS_CSS } from '@/core/constants'
 
 import { parseText } from './utils'
 
@@ -26,11 +26,7 @@ declare global {
          getContainer(): Chainable<any>
          checkSlotAgainst(obj: Record<string, any>): Chainable<any>
          checkSlotPropsAgainst(obj: Record<string, any>): Chainable<any>
-         checkAnimations(
-            enterClass: string,
-            leaveClass: string,
-            clearAllClass: string
-         ): Chainable<any>
+         checkAnimations(): Chainable<any>
          checkTransitions(element: HTMLElement, height: number): Chainable<any>
       }
    }
@@ -101,27 +97,30 @@ Cypress.Commands.add('checkSlotPropsAgainst', (obj: Record<string, any>) =>
    cy.getNotifications().then((el) => cy.wrap(parseText(el).props).should('eql', obj))
 )
 
-Cypress.Commands.add(
-   'checkAnimations',
-   (enterClass: string, leaveClass: string, clearAllClass: string) => {
-      cy.get('.Success').click()
+Cypress.Commands.add('checkAnimations', () => {
+   cy.get('.Success').click()
 
-      cy.get(enterClass).should('exist').get(leaveClass).should('not.exist').wait(DEFAULT_DURATION)
+   cy.getContainer()
+      .should('have.attr', 'style')
+      .and('include', MOTION_VARS_CSS.enterAnimation)
+      .getContainer()
+      .invoke('attr', 'style')
+      .should('not.include', MOTION_VARS_CSS.leaveAnimation)
+      .wait(DEFAULT_DURATION)
 
-      cy.get(leaveClass).should('exist').get(enterClass).should('not.exist')
+   cy.getContainer().should('have.attr', 'style').and('include', MOTION_VARS_CSS.leaveAnimation)
 
-      cy.get('.Success').click()
+   cy.get('.Success').click()
 
-      cy.get('.ClearAll').click()
+   cy.get('.ClearAll').click()
 
-      cy.get(clearAllClass).should('exist')
-   }
-)
+   cy.get('ol').should('have.attr', 'style').and('include', MOTION_VARS_CSS.clearAllAnimation)
+})
 
 Cypress.Commands.add('checkTransitions', (element: HTMLElement, height: number) =>
    cy
       .wrap(element)
       .should('have.attr', 'style')
       .and('include', `transform: translate3d(0px, ${height}px, 0px)`)
-      .and('include', 'transition: transform 0.35s cubic-bezier(0.5, 1, 0.25, 1)')
+      .and('include', MOTION_VARS_CSS.transformTransition)
 )


### PR DESCRIPTION
## Summary

- Remove `animations` and `transition` from `NotivueConfig` in favor of CSS variables (`--nv-enter-animation`, `--nv-leave-animation`, `--nv-clear-all-animation`, `--nv-transform-transition`).
- Store injects `MOTION_VARS_CSS` inline for enter/leave/clearAll and stack repositioning; reposition keeps a JS fallback when the transition variable is unset.
- Default keyframes and variable values live in `notivue/animations.css`, so default motion keeps working on package upgrade without config changes.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test:unit`
- [ ] `pnpm test` (Cypress component suite)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Animation system now uses CSS custom properties instead of class-based animations.
  * Animation settings removed from the public config, simplifying the API while preserving customization and reduced-motion handling.
* **Tests**
  * Test suites updated to assert motion via CSS variables and inline styles.
* **Chores**
  * CI workflow updated to include the v3 branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->