### PR TITLE
Core, Notivue - Config improvements for v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,10 @@ Notivue is a public OSS Vue 3 toast notification library. Treat `packages/notivu
 
 ## Notivue stream layout
 
-- Notification rows use `width: max-content` on `<li data-notivue-list-item>` so keyboard focus rings hug the toast. Stream focus and `aria-label` belong on the `<li>`; `[data-notivue-item]` is not focusable.
+- Notification rows use `width: max-content` on `<li data-notivue-item>` so keyboard focus rings hug the toast. Stream focus and `aria-label` belong on the `<li>`; `[data-notivue-container]` is not focusable.
 - Horizontal alignment follows `position` (`*-left`, `*-center`, `*-right`). Responsive changes use `config.update` / `updateConfig`, not CSS alignment overrides.
 - `--nv-gap` is block-end margin on list items. Stacking uses `getListItemStackHeight` in `packages/notivue/core/utils.ts`.
-- `NotivueKeyboard` `isCandidate` receives the `<li>` (`[data-notivue-list-item]`), same element as stream focus.
+- `NotivueKeyboard` `isCandidate` receives the `<li>` (`[data-notivue-item]`), same element as stream focus.
 
 ## Workflow
 

--- a/packages/notivue/Notivue/Notivue.vue
+++ b/packages/notivue/Notivue/Notivue.vue
@@ -17,7 +17,14 @@ defineSlots<NotivueComponentSlot>()
 
 <template>
    <NotivueClientOnly>
-      <NotivueImpl v-bind="props" v-slot="item" v-if="isRunning">
+      <NotivueImpl
+         v-if="isRunning"
+         v-slot="item"
+         :class="props.class"
+         :listAriaLabel="props.listAriaLabel"
+         :styles="props.styles"
+         :teleportTo="props.teleportTo ?? null"
+      >
          <slot v-bind="item" />
       </NotivueImpl>
    </NotivueClientOnly>

--- a/packages/notivue/Notivue/NotivueImpl.vue
+++ b/packages/notivue/Notivue/NotivueImpl.vue
@@ -8,7 +8,7 @@ import { Teleport } from 'vue'
 import { useStore } from '@/core/useStore'
 import { getSlotItem } from '@/core/utils'
 
-import { DEFAULT_PROPS } from './constants'
+import { DEFAULT_IMPL_PROPS } from './constants'
 
 import { useFocusEvents } from './composables/useFocusEvents'
 import { useMouseEvents } from './composables/useMouseEvents'
@@ -21,7 +21,11 @@ import { getAriaLabel } from './utils'
 
 // Props
 
-const props = withDefaults(defineProps<NotivueProps>(), DEFAULT_PROPS)
+type NotivueImplProps = Omit<NotivueProps, 'teleportTo'> & {
+   teleportTo?: NotivueProps['teleportTo'] | null
+}
+
+const props = withDefaults(defineProps<NotivueImplProps>(), DEFAULT_IMPL_PROPS)
 
 defineSlots<NotivueComponentSlot>()
 
@@ -39,13 +43,20 @@ const touchEvents = useTouchEvents()
 useReducedMotion()
 useWindowFocus()
 useSizes()
+
+function getTeleportChoice() {
+   return props.teleportTo === null ? config.teleportTo.value : props.teleportTo
+}
+
+function getTeleportTo() {
+   const choice = getTeleportChoice()
+
+   return choice === false ? undefined : choice
+}
 </script>
 
 <template>
-   <Teleport
-      :to="config.teleportTo.value === false ? undefined : config.teleportTo.value"
-      :disabled="config.teleportTo.value === false"
-   >
+   <Teleport :to="getTeleportTo()" :disabled="getTeleportChoice() === false">
       <!-- List Container -->
       <ol
          v-if="items.entries.value.length > 0"

--- a/packages/notivue/Notivue/NotivueImpl.vue
+++ b/packages/notivue/Notivue/NotivueImpl.vue
@@ -73,7 +73,7 @@ function getTeleportTo() {
             v-for="(item, i) in items.entries.value"
             :tabindex="item.ariaLiveOnly ? undefined : -1"
             :key="item.id"
-            :data-notivue-list-item="item.id"
+            :data-notivue-item="item.id"
             :aria-label="item.ariaLiveOnly ? undefined : getAriaLabel(item)"
             :aria-setsize="items.length"
             :aria-posinset="i + 1"
@@ -85,13 +85,13 @@ function getTeleportTo() {
             }"
          >
             <!-- ariaLiveOnly Push Option -->
-            <AriaLive v-if="item.ariaLiveOnly" :item="item" data-notivue-aria-live="" />
+            <AriaLive v-if="item.ariaLiveOnly" :item="item" />
 
             <!-- Item Container -->
             <div
                v-else
                v-bind="item.animationAttrs"
-               :data-notivue-item="item.id"
+               :data-notivue-container="item.id"
                :ref="elements.itemContainers"
                :style="{ ...styles.itemContainer, ...props.styles?.itemContainer }"
             >

--- a/packages/notivue/Notivue/constants.ts
+++ b/packages/notivue/Notivue/constants.ts
@@ -1,3 +1,8 @@
 export const DEFAULT_PROPS = {
    listAriaLabel: 'Notifications',
 } as const
+
+export const DEFAULT_IMPL_PROPS = {
+   ...DEFAULT_PROPS,
+   teleportTo: null,
+} as const

--- a/packages/notivue/Notivue/types.ts
+++ b/packages/notivue/Notivue/types.ts
@@ -32,6 +32,14 @@ export interface NotivueProps {
     * @default undefined
     */
    styles?: Partial<Record<NotivueElements, CSSProperties>>
+   /**
+    * Vue Teleport target for the stream container. Takes priority over `teleportTo` in config.
+    *
+    * Prefer this prop when you need a non-serializable value (e.g. `HTMLElement`).
+    *
+    * @default undefined (uses config.teleportTo)
+    */
+   teleportTo?: string | HTMLElement | false
 }
 
 export interface NotivueComponentSlot {

--- a/packages/notivue/NotivueKeyboard/NotivueKeyboardImpl.vue
+++ b/packages/notivue/NotivueKeyboard/NotivueKeyboardImpl.vue
@@ -115,7 +115,7 @@ function setCandidates(newItems: HTMLElement[]) {
 
    newItems
       .filter((item) => {
-         const id = item.dataset.notivueListItem
+         const id = item.dataset.notivueItem
 
          if (!id) return false
 
@@ -123,7 +123,7 @@ function setCandidates(newItems: HTMLElement[]) {
 
          return Boolean(entry && !entry.ariaLiveOnly)
       })
-      .sort((a, b) => +b.dataset.notivueListItem! - +a.dataset.notivueListItem!)
+      .sort((a, b) => +b.dataset.notivueItem! - +a.dataset.notivueItem!)
       .forEach((item) => {
          const innerFocusableEls = Array.from(item.querySelectorAll(focusableEls)).filter(
             (el) => el instanceof HTMLElement

--- a/packages/notivue/NotivueKeyboard/types.ts
+++ b/packages/notivue/NotivueKeyboard/types.ts
@@ -15,7 +15,7 @@ export interface NotivueKeyboardData {
 export interface NotivueKeyboardProps {
    /**
     * Custom function to determine if a notification list item is a candidate for
-    * keyboard navigation. Receives the `<li>` element (`[data-notivue-list-item]`).
+    * keyboard navigation. Receives the `<li>` element (`[data-notivue-item]`).
     *
     * By default, a list item is a candidate if it contains at least one focusable
     * element (buttons, links, inputs, selects, textareas, or elements with a non-negative `tabindex`).

--- a/packages/notivue/astro/Notivue.vue
+++ b/packages/notivue/astro/Notivue.vue
@@ -69,7 +69,13 @@ onBeforeUnmount(() => {
 
 <template>
    <NotivueClientOnly>
-      <NotivueImpl v-bind="props" v-slot="item">
+      <NotivueImpl
+         v-slot="item"
+         :class="props.class"
+         :listAriaLabel="props.listAriaLabel"
+         :styles="props.styles"
+         :teleportTo="props.teleportTo ?? null"
+      >
          <slot v-bind="item" />
       </NotivueImpl>
    </NotivueClientOnly>

--- a/packages/notivue/core/createInstance.ts
+++ b/packages/notivue/core/createInstance.ts
@@ -1,11 +1,11 @@
-import type { NotivueStore, Notify } from 'notivue'
+import type { NotivueConfigUpdateParam, NotivueStore, Notify } from 'notivue'
 
 import { readonly, ref } from 'vue'
 
 import { createNotifyMock, setNotify } from './createNotify'
 import { createStoreWatchers } from './createStoreWatchers'
 
-export let startInstance: () => void = () => {}
+export let startInstance: (config?: NotivueConfigUpdateParam) => void = () => {}
 export let stopInstance: () => void = () => {}
 
 export function createInstance(startOnCreation: boolean) {
@@ -21,7 +21,7 @@ export function createInstance(startOnCreation: boolean) {
 
       const instance = {
          isRunning: isRunningReadonly,
-         startInstance() {
+         startInstance(config?: NotivueConfigUpdateParam) {
             if (isRunning.value) return
 
             setNotify(notify)
@@ -29,6 +29,8 @@ export function createInstance(startOnCreation: boolean) {
             unwatchStore = watchStore()
 
             isRunning.value = true
+
+            if (config !== undefined) store.config.update(config)
          },
          stopInstance() {
             if (!isRunning.value) return
@@ -44,7 +46,7 @@ export function createInstance(startOnCreation: boolean) {
          },
       }
 
-      startInstance = () => instance.startInstance()
+      startInstance = (config?: NotivueConfigUpdateParam) => instance.startInstance(config)
       stopInstance = () => instance.stopInstance()
 
       return instance

--- a/packages/notivue/core/createInstance.ts
+++ b/packages/notivue/core/createInstance.ts
@@ -22,7 +22,11 @@ export function createInstance(startOnCreation: boolean) {
       const instance = {
          isRunning: isRunningReadonly,
          startInstance(config?: NotivueConfigUpdateParam) {
-            if (isRunning.value) return
+            if (isRunning.value) {
+               if (config !== undefined) store.config.update(config)
+
+               return
+            }
 
             setNotify(notify)
 

--- a/packages/notivue/core/createStore.ts
+++ b/packages/notivue/core/createStore.ts
@@ -184,9 +184,7 @@ export function createElements() {
       itemContainers: ref<HTMLElement[]>([]),
       getSortedItems() {
          // This is a bit dirty, but it's better than cloning and reversing the array on every repositioning
-         return this.items.value.sort(
-            (a, b) => +b.dataset.notivueListItem! - +a.dataset.notivueListItem!
-         )
+         return this.items.value.sort((a, b) => +b.dataset.notivueItem! - +a.dataset.notivueItem!)
       },
    } as {
       // Suppress TS7056
@@ -258,7 +256,9 @@ export function createAnimations(
          items.addLifecycleEvent()
 
          requestAnimationFrame(() => {
-            const el = elements.itemContainers.value.find((el) => el.dataset.notivueItem === id)
+            const el = elements.itemContainers.value.find(
+               (el) => el.dataset.notivueContainer === id
+            )
 
             if (el && getComputedStyle(el).animationName === 'none') onAnimationend()
          })
@@ -298,7 +298,7 @@ export function createAnimations(
          let accPrevHeights = 0
 
          for (const el of elements.getSortedItems()) {
-            const id = el.dataset.notivueListItem!
+            const id = el.dataset.notivueItem!
             const item = items.get(id)
 
             if (!el || !item) continue

--- a/packages/notivue/core/types.ts
+++ b/packages/notivue/core/types.ts
@@ -251,7 +251,7 @@ export type ElementsSlice = ReturnType<typeof createElements>
 
 export interface NotivueInstance {
    isRunning: Readonly<Ref<boolean>>
-   startInstance: () => void
+   startInstance: (config?: NotivueConfigUpdateParam) => void
    stopInstance: () => void
 }
 

--- a/packages/notivue/core/types.ts
+++ b/packages/notivue/core/types.ts
@@ -272,6 +272,7 @@ export interface NotivueComputedEntries {
 export type UseNotivueReturn = Prettify<
    ConfigSlice & {
       isStreamPaused: ComputedRef<boolean>
+      isStreamFocused: ComputedRef<boolean>
       /** @deprecated Create computed property instead: `computed(() => config.position.value.startsWith('top'))`. */
       isTopAlign: ComputedRef<boolean>
    }

--- a/packages/notivue/core/useStore.ts
+++ b/packages/notivue/core/useStore.ts
@@ -3,6 +3,7 @@ import type {
    UseNotivueReturn,
    NotivueComputedEntries,
    NotivueInstance,
+   NotivueConfigUpdateParam,
 } from 'notivue'
 
 import { inject, computed, toRefs, reactive, readonly, ref, type ComputedRef } from 'vue'
@@ -32,7 +33,7 @@ export function useNotivueInstance(): NotivueInstance {
    if (isSSR) {
       return {
          isRunning: ref(true),
-         startInstance: (_config?) => {},
+         startInstance: (_config?: NotivueConfigUpdateParam): void => {},
          stopInstance: () => {},
       } as NotivueInstance
    }

--- a/packages/notivue/core/useStore.ts
+++ b/packages/notivue/core/useStore.ts
@@ -22,7 +22,7 @@ export function useStore() {
  *
  * @returns
  *
- * - `startInstance` - Starts or restarts the Notivue instance.
+ * - `startInstance` - Starts or restarts the Notivue instance. Optionally accepts a config patch.
  * - `stopInstance` - Stops the Notivue instance.
  * - `isRunning` - Readonly ref to check if the Notivue instance is running.
  *
@@ -32,7 +32,7 @@ export function useNotivueInstance(): NotivueInstance {
    if (isSSR) {
       return {
          isRunning: ref(true),
-         startInstance: () => {},
+         startInstance: (_config?) => {},
          stopInstance: () => {},
       } as NotivueInstance
    }

--- a/packages/notivue/core/useStore.ts
+++ b/packages/notivue/core/useStore.ts
@@ -58,6 +58,7 @@ export function useNotivue(): UseNotivueReturn {
          update: () => {},
          isTopAlign: computed(() => true),
          isStreamPaused: ref(false) as ComputedRef<boolean>,
+         isStreamFocused: ref(false) as ComputedRef<boolean>,
       } as UseNotivueReturn
    }
 
@@ -66,6 +67,7 @@ export function useNotivue(): UseNotivueReturn {
    return {
       ...store.config,
       isStreamPaused: readonly(store.timeouts.isStreamPaused) as ComputedRef<boolean>,
+      isStreamFocused: readonly(store.timeouts.isStreamFocused) as ComputedRef<boolean>,
       isTopAlign: computed(() => store.config.position.value.indexOf('top') === 0),
    }
 }

--- a/playground/assets/notivue-stream.css
+++ b/playground/assets/notivue-stream.css
@@ -1,12 +1,12 @@
 /*
- * Playground stream styles (NotivueKeyboard focuses [data-notivue-list-item]).
+ * Playground stream styles (NotivueKeyboard focuses [data-notivue-item] on <li>).
  */
 
-[data-notivue-list-item]:focus-visible {
+[data-notivue-item]:focus-visible {
    outline: none;
 }
 
-[data-notivue-list-item]:focus-visible .Notification,
-[data-notivue-list-item]:focus-visible .Notivue__notification {
+[data-notivue-item]:focus-visible .Notification,
+[data-notivue-item]:focus-visible .Notivue__notification {
    box-shadow: var(--focus-ring-xl);
 }

--- a/tests/Notivue/attributes.cy.ts
+++ b/tests/Notivue/attributes.cy.ts
@@ -9,16 +9,19 @@ it('Notivue attributes are added correctly', () => {
 
       .get('ol')
       .should('have.class', 'CustomClass')
-      .and('have.attr', 'data-notivue-align')
+      .should(($ol) => {
+         expect($ol[0].hasAttribute('data-notivue-list')).to.be.true
+         expect($ol).to.have.attr('data-notivue-align')
+      })
 
    cy.get('li').should(($li) => {
       expect($li).to.have.attr('tabindex', '-1')
-      expect($li).to.have.attr('data-notivue-list-item')
+      expect($li).to.have.attr('data-notivue-item')
       expect($li).to.have.attr('aria-label')
    })
 
    cy.get('li > div').should(($container) => {
-      expect($container).to.have.attr('data-notivue-item')
+      expect($container).to.have.attr('data-notivue-container')
       expect($container).not.to.have.attr('tabindex')
    })
 })

--- a/tests/Notivue/components/Notivue.vue
+++ b/tests/Notivue/components/Notivue.vue
@@ -171,7 +171,7 @@ async function pushPromiseAndReject() {
 
       <!-------------------------------- Instance Tests ---------------------------------->
 
-      <button class="StartInstance" @click="startInstance">Start Instance</button>
+      <button class="StartInstance" @click="startInstance()">Start Instance</button>
       <button class="StopInstance" @click="stopInstance">Stop Instance</button>
       <div class="QueueCount">{{ queue.length }}</div>
       <div class="EntriesCount">{{ entries.length }}</div>

--- a/tests/Notivue/config-teleport.cy.ts
+++ b/tests/Notivue/config-teleport.cy.ts
@@ -1,80 +1,89 @@
-import type { VueWrapper } from '@vue/test-utils'
+import NotivueImpl from '@/Notivue/NotivueImpl.vue'
+
+import type { App } from 'vue'
 
 import { mount } from 'cypress/vue'
-import { Notivue, createNotivue, push } from 'notivue'
+import { type NotivueConfig, type Notify } from 'notivue'
 
-describe('Teleport', () => {
-   it('By default is teleported to body', () => {
-      cy.mountNotivue()
+import { createProvides } from '@/core/createNotivue'
+import { notivueInjectionKey, notivueInstanceInjectionKey } from '@/core/symbols'
 
-         .clickRandomStatic()
+const listSelector = '[data-notivue-list]'
 
-         .get('body')
-         .children()
-         .should('have.class', 'Root')
-   })
+function mountRoot(config: NotivueConfig = {}, props = {}) {
+   const { store, instance, notify } = createProvides(true, config)
 
-   it('Can teleport to different element', () => {
-      cy.mountNotivue({ config: { teleportTo: 'html' } })
-
-         .clickRandomStatic()
-
-         .get('body')
-         .children()
-         .should('not.have.class', 'Root')
-
-         .get('html')
-         .children()
-         .should('have.class', 'Root')
-   })
-
-   it('Can teleport to custom HTMLElement', () => {
-      cy.mountNotivue({
-         config: { teleportTo: document.getElementById('teleport') as HTMLElement },
-      })
-
-         .clickRandomStatic()
-
-         .get('body')
-         .children()
-         .should('not.have.class', 'Root')
-
-         .get('#teleport')
-         .children()
-         .should('have.class', 'Root')
-   })
-
-   it('Can update teleport config dynamically', () => {
-      cy.mountNotivue()
-         .get<VueWrapper>('@vue')
-         .then((wrapper) => wrapper.setProps({ teleportTo: 'html' }))
-
-         .clickRandomStatic()
-
-         .get('body')
-         .children()
-         .should('not.have.class', 'Root')
-
-         .get('html')
-         .children()
-         .should('have.class', 'Root')
-   })
-
-   it('Prop takes priority over config teleportTo', () => {
-      const notivue = createNotivue({ teleportTo: 'body' })
-
-      mount(Notivue, {
-         global: { plugins: [notivue] },
-         props: { teleportTo: 'html', class: 'Root' },
+   return mount(
+      NotivueImpl as any,
+      {
+         global: {
+            plugins: [
+               {
+                  install(app: App) {
+                     app.provide(notivueInstanceInjectionKey, instance)
+                     app.provide(notivueInjectionKey, store)
+                  },
+               },
+            ],
+         },
+         props: { class: 'Root', ...props },
          slots: {
             default: () => null,
          },
+      } as any
+   ).then((result) => ({ ...result, notify }))
+}
+
+function pushNotification(notify: Notify) {
+   notify.success({ message: 'test' })
+}
+
+describe('Teleport', () => {
+   it('By default is teleported to body', () => {
+      mountRoot().then(({ notify }) => pushNotification(notify))
+
+      cy.get(`body > ${listSelector}`).should('exist')
+   })
+
+   it('Can teleport to different element', () => {
+      mountRoot({ teleportTo: 'html' }).then(({ notify }) => pushNotification(notify))
+
+      cy.get(`body > ${listSelector}`).should('not.exist')
+      cy.get(`html > ${listSelector}`).should('exist')
+   })
+
+   it('Can teleport to custom HTMLElement', () => {
+      cy.document()
+         .then((doc) => {
+            const teleportTo = doc.createElement('div')
+
+            teleportTo.id = 'teleport'
+
+            doc.body.appendChild(teleportTo)
+
+            return mountRoot({ teleportTo })
+         })
+         .then(({ notify }) => pushNotification(notify))
+
+      cy.get(`body > ${listSelector}`).should('not.exist')
+      cy.get(`#teleport > ${listSelector}`).should('exist')
+   })
+
+   it('Can update teleport config dynamically', () => {
+      mountRoot().then(({ wrapper, notify }) => {
+         return wrapper.setProps({ teleportTo: 'html' }).then(() => pushNotification(notify))
       })
 
-      cy.wrap(null).then(() => {
-         push.success({ message: 'test' })
-      })
+      cy.get(`body > ${listSelector}`).should('not.exist')
+      cy.get(`html > ${listSelector}`).should('exist')
+   })
 
-      cy.get('html').children().should('have.class', 'Root')
+   it('Prop takes priority over config teleportTo', () => {
+      mountRoot({ teleportTo: 'body' }, { teleportTo: 'html' }).then(({ notify }) =>
+         pushNotification(notify)
+      )
+
+      cy.get(`body > ${listSelector}`).should('not.exist')
+      cy.get(`html > ${listSelector}`).should('exist')
    })
 })

--- a/tests/Notivue/config-teleport.cy.ts
+++ b/tests/Notivue/config-teleport.cy.ts
@@ -1,5 +1,8 @@
 import type { VueWrapper } from '@vue/test-utils'
 
+import { mount } from 'cypress/vue'
+import { Notivue, createNotivue, push } from 'notivue'
+
 describe('Teleport', () => {
    it('By default is teleported to body', () => {
       cy.mountNotivue()
@@ -55,5 +58,23 @@ describe('Teleport', () => {
          .get('html')
          .children()
          .should('have.class', 'Root')
+   })
+
+   it('Prop takes priority over config teleportTo', () => {
+      const notivue = createNotivue({ teleportTo: 'body' })
+
+      mount(Notivue, {
+         global: { plugins: [notivue] },
+         props: { teleportTo: 'html', class: 'Root' },
+         slots: {
+            default: () => null,
+         },
+      })
+
+      cy.wrap(null).then(() => {
+         push.success({ message: 'test' })
+      })
+
+      cy.get('html').children().should('have.class', 'Root')
    })
 })

--- a/tests/Notivue/instance.cy.ts
+++ b/tests/Notivue/instance.cy.ts
@@ -1,5 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 
+import { startInstance } from 'notivue'
+
 function testStoppedInstance() {
    cy.getNotifications().should('have.length', 0, { timeout: 0 })
    cy.get('.QueueCount').should('have.text', '0')
@@ -59,6 +61,25 @@ it('Instance can be stopped and started again', () => {
          .get('.EntriesCount')
          .should('have.text', '4', { timeout: 0 })
    }
+})
+
+it('startInstance accepts config', () => {
+   cy.mountNotivue({
+      config: {
+         startOnCreation: false,
+         position: 'top-center',
+      },
+   })
+
+   cy.wrap(null).then(() => {
+      startInstance({ position: 'bottom-center' })
+   })
+
+   cy.clickAllStatic()
+      .get('[data-notivue-list]')
+      .should('have.attr', 'data-notivue-align', 'bottom')
+      .getNotifications()
+      .should('have.length', 4, { timeout: 0 })
 })
 
 it('Config is not updated if instance is stopped', () => {

--- a/tests/Notivue/prefers-reduced-motion.cy.ts
+++ b/tests/Notivue/prefers-reduced-motion.cy.ts
@@ -11,7 +11,7 @@ describe('prefers-reduced-motion', () => {
       cy.mountNotivue()
          .get('.PushAndRenderClear')
          .click()
-         .get('[data-notivue-item]')
+         .get('[data-notivue-container]')
          .should('exist')
          .should(($el) => {
             expect($el.attr('style') ?? '').not.to.include(MOTION_VARS_CSS.enterAnimation)
@@ -19,7 +19,7 @@ describe('prefers-reduced-motion', () => {
 
          .get('.RenderedClear')
          .click()
-         .get('[data-notivue-item]')
+         .get('[data-notivue-container]')
          .should('not.exist')
          .get(`[style*="${MOTION_VARS_CSS.leaveAnimation}"]`)
          .should('not.exist')

--- a/tests/NotivueKeyboard/actions.cy.ts
+++ b/tests/NotivueKeyboard/actions.cy.ts
@@ -11,7 +11,7 @@ describe('Actions', () => {
 
          .pushCandidateSilently() // id: 3
          .focused()
-         .should('have.data', 'notivueListItem', 3)
+         .should('have.data', 'notivueItem', 3)
    })
 
    it('Should focus next container if clicking an action', () => {
@@ -29,7 +29,7 @@ describe('Actions', () => {
          .realPress(Math.random() > 0.5 ? 'Space' : 'Enter')
 
          .focused()
-         .should('have.data', 'notivueListItem', 0)
+         .should('have.data', 'notivueItem', 0)
    })
 
    it('Should focus previous candidate if pressing Space or Enter on action in last container', () => {
@@ -47,7 +47,7 @@ describe('Actions', () => {
          .realPress(Math.random() > 0.5 ? 'Space' : 'Enter')
 
          .focused()
-         .should('have.data', 'notivueListItem', 1) // Falls back to previous candidate
+         .should('have.data', 'notivueItem', 1) // Falls back to previous candidate
    })
 
    it('Should leave stream if clicking with mouse an action in any container', () => {

--- a/tests/NotivueKeyboard/entering-stream.cy.ts
+++ b/tests/NotivueKeyboard/entering-stream.cy.ts
@@ -21,7 +21,7 @@ describe('Entering the stream', () => {
       cy.realPress('Tab')
 
          .focused()
-         .should('have.data', 'notivueListItem')
+         .should('have.data', 'notivueItem')
    })
 
    it('If an unqualified notification is pushed, it should not be focused if tab is pressed', () => {
@@ -49,7 +49,7 @@ describe('Entering the stream', () => {
          .realPress('Tab')
 
          .focused()
-         .should('have.data', 'notivueListItem', limit - 1)
+         .should('have.data', 'notivueItem', limit - 1)
    })
 
    it('If never navigated and unqualified are pushed after candidates, the first candidate should be focused once tab is pressed', () => {
@@ -62,7 +62,7 @@ describe('Entering the stream', () => {
          .realPress('Tab')
 
          .focused()
-         .should('have.data', 'notivueListItem', 1) // Ids starts from 0
+         .should('have.data', 'notivueItem', 1) // Ids starts from 0
    })
 
    it('Should enter with CTRL+N', () => {
@@ -73,7 +73,7 @@ describe('Entering the stream', () => {
          .realPress(['ControlLeft', 'n'])
 
          .focused()
-         .should('have.data', 'notivueListItem', 0)
+         .should('have.data', 'notivueItem', 0)
    })
 
    it('Should not enter with Tab if already navigated and no new candidates are available', () => {

--- a/tests/NotivueKeyboard/props.cy.ts
+++ b/tests/NotivueKeyboard/props.cy.ts
@@ -35,7 +35,7 @@ describe('Props', () => {
          .realPress(['ControlLeft', 'u'])
 
          .focused()
-         .should('have.data', 'notivueListItem', 0)
+         .should('have.data', 'notivueItem', 0)
 
          .realPress(['ControlLeft', 'u'])
 
@@ -76,7 +76,7 @@ describe('Props', () => {
          .realPress('Tab')
 
          .focused()
-         .should('have.data', 'notivueListItem')
+         .should('have.data', 'notivueItem')
    })
 
    it('Should qualify list items via isCandidate when they have no focusable children', () => {
@@ -86,7 +86,7 @@ describe('Props', () => {
          .realPress('Tab')
 
          .focused()
-         .should('have.data', 'notivueListItem')
+         .should('have.data', 'notivueItem')
    })
 
    it('Should pass list items to isCandidate', () => {
@@ -99,8 +99,8 @@ describe('Props', () => {
 
             const el = isCandidate.firstCall.args[0] as HTMLElement
 
-            expect(el.dataset.notivueListItem).to.exist
-            expect(el.hasAttribute('data-notivue-item')).to.be.false
+            expect(el.dataset.notivueItem).to.exist
+            expect(el.tagName).to.equal('LI')
          })
    })
 

--- a/tests/NotivueKeyboard/queue.cy.ts
+++ b/tests/NotivueKeyboard/queue.cy.ts
@@ -9,7 +9,7 @@ describe('Queue', () => {
          .realPress('Tab')
          .realPress('Space') // Dismiss first candidate (id: 0)
          .focused()
-         .and('have.data', 'notivueListItem', 1)
+         .and('have.data', 'notivueItem', 1)
    })
 
    it('Should focus first candidate available if unqualified is pushed from the queue', () => {
@@ -23,7 +23,7 @@ describe('Queue', () => {
          .realPress('Tab')
          .realPress('Space') // Dismiss last candidate (id: 1)
          .focused()
-         .and('have.data', 'notivueListItem', 0)
+         .and('have.data', 'notivueItem', 0)
    })
 
    it('Should leave the stream if unqualified is pushed and no candidates are available', () => {


### PR DESCRIPTION
## Summary

* Core - `startInstance` accepts an optional config patch (same shape as `updateConfig`); patch applies even when the instance is already running
* Notivue - Add `teleportTo` prop on `<Notivue />`; prop takes priority over config `teleportTo`
* Core - Expose `isStreamFocused` on `useNotivue`, consistent with `isStreamPaused`
* Notivue - Keep `data-notivue-list` on the stream `<ol>`; restore `data-notivue-item` on `<li>` and `data-notivue-container` on animation wrappers (main-compatible names)
* Tests - Rewrite `config-teleport.cy.ts` to mount `NotivueImpl` with stable `[data-notivue-list]` assertions

## Test plan

- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] Cypress: `Notivue/config-teleport.cy.ts` (5/5)
- [x] Cypress: `instance.cy.ts` (`startInstance accepts config`)
- [x] Cypress: `attributes.cy.ts`, `prefers-reduced-motion.cy.ts`, `NotivueKeyboard/*.cy.ts` (stream data attributes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * startInstance now accepts an optional config at startup.
  * New teleportTo prop to override teleport target.
  * isStreamFocused exposure to track stream focus.

* **Bug Fixes / Behavior**
  * Standardized data-* attributes for list/items/containers and adjusted Teleport handling.

* **Documentation**
  * Updated keyboard focus and stream layout guidance.

* **Tests**
  * Updated and added tests for teleport precedence, startInstance config, and attribute/key-focus expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->